### PR TITLE
Fix return type

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -82,7 +82,7 @@ contributors: J. S. Choi
               1. If _defineStatus_ is an abrupt completion, return ? AsyncIteratorClose(_iteratorRecord_, _defineStatus_).
               1. Set _k_ to _k_ + 1.
           1. Perform AsyncFunctionStart(promiseCapability, _fromAsyncClosure_).
-          1. Return Completion { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
+          1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
         <emu-note>
           <p>The `fromAsync` function is an intentionally generic factory method; it does not require that its *this* value be the Array constructor. Therefore it can be transferred to or inherited by any other constructors that may be called with a single numeric argument.</p>

--- a/spec.html
+++ b/spec.html
@@ -81,7 +81,7 @@ contributors: J. S. Choi
               1. Let _defineStatus_ be CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
               1. If _defineStatus_ is an abrupt completion, return ? AsyncIteratorClose(_iteratorRecord_, _defineStatus_).
               1. Set _k_ to _k_ + 1.
-          1. Perform AsyncFunctionStart(promiseCapability, _fromAsyncClosure_).
+          1. Perform AsyncFunctionStart(_promiseCapability_, _fromAsyncClosure_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
The current spec misuses `~return~` completions. Those are use for propagating a literal syntactic `return` in an ES function up through any intermediate syntax (which is handled by the `?` macro) to the `[[Call]]` AO which invoked the function, where it is unwrapped into a normal completion (in step 10.2.1 of [that algorithm](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ecmascript-function-objects-call-thisargument-argumentslist)).

Built-in functions do not need to deal with that propagation, so they can (and do) just return a normal completion holding the value in question directly. [The `[[Call]]` semantics for built-in functions](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-built-in-function-objects-call-thisargument-argumentslist) have no corresponding return->normal unwrapping.

(The current spec text ends up propagating a return completion to the _caller_ - that is, as currently written, it would cause a `return` from the code _which called `fromAsync`_.)