### PR TITLE
spec: fix typo

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -59,7 +59,7 @@ contributors: J. S. Choi
             1. If _usingAsyncIterator_ is not *undefined*, then
               1. Let _iteratorRecord_ be ? GetIterator(_asyncItems_, ~async~, _usingAsyncIterator_).
             1. Else,
-              1. Let _iteratorRecord_ be ? CreateAsyncFromSyncIterator(GetIterator(_syncItems_, ~sync~, _usingSyncIterator_)).
+              1. Let _iteratorRecord_ be ? CreateAsyncFromSyncIterator(GetIterator(_asyncItems_, ~sync~, _usingSyncIterator_)).
             1. Let _k_ be 0.
             1. Repeat,
               1. If _k_ &ge; 2<sup>53</sup> - 1, then


### PR DESCRIPTION
I assume `syncItems` is meant to be `asyncItems` here?