### PR TITLE
Fix badCallback will only throw if iterable has items

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Array.fromAsync(badIterable);
 Array.fromAsync(genError());
 Array.fromAsync(genRejection());
 Array.fromAsync(genErrorAsync());
-Array.fromAsync([], badCallback);
+Array.fromAsync([1], badCallback);
 BadConstructor.call(Array.fromAsync, []);
 // These create promises that will reject with TypeErrors.
 Array.fromAsync(null);


### PR DESCRIPTION
This is consistent with Array.from where `Array.from([], ()=>{throw 1})` will not throw but `Array.from([1], ()=>{throw 1})` will.
