### PR TITLE
Add IfAbruptCloseAsyncIterator

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -87,8 +87,6 @@ contributors: J. S. Choi
         </emu-alg>
       </emu-clause>
     </emu-clause>
-    </emu-clause>
-
   </emu-clause>
 </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -19,6 +19,33 @@ contributors: J. S. Choi
   explainer</a> for the proposal's background, motivation, and usage examples.</p>
 </emu-intro>
 
+<emu-clause id="sec-control-abstraction-objects">
+  <h1>Control Abstraction Objects</h1>
+
+  <emu-clause id="sec-iteration">
+    <h1>Iteration</h1>
+
+    <emu-clause id="sec-iterator-abstract-operations">
+      <h1>Iterator Abstract Operations</h1>
+
+      <emu-clause id="sec-ifabruptcloseasynciterator" aoid="IfAbruptCloseAsyncIterator">
+        <h1>IfAbruptCloseAsyncIterator ( _value_, _iteratorRecord_ )</h1>
+        <p><dfn>IfAbruptCloseAsyncIterator</dfn> is a shorthand for a sequence of algorithm steps that use an Iterator Record. An algorithm step of the form:</p>
+        <emu-alg>
+          1. IfAbruptCloseAsyncIterator(_value_, _iteratorRecord_).
+        </emu-alg>
+        <p>means the same thing as:</p>
+        <emu-alg>
+          1. If _value_ is an abrupt completion, then
+            1. Perform ? AsyncIteratorClose(_iteratorRecord_, _value_).
+            1. Return _value_.
+          1. Else if _value_ is a Completion Record, set _value_ to _value_.[[Value]].
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>
+
 <emu-clause id="sec-indexed-collections">
   <h1>Indexed Collections</h1>
 


### PR DESCRIPTION
This pull request adds missing abstract operation, `IfAbruptCloseAsyncIterator` in the proposal spec text. 
The description of the abstract operation has been taken from proposal iterator helpers: https://tc39.es/proposal-iterator-helpers/#sec-ifabruptcloseasynciterator