### PR TITLE
Revert #20 and do not await async inputs’ values without mapping ƒ

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,15 @@ const d = await Data.fromAsync(asyncGen(4));
 ### Optional parameters
 Array.fromAsync has two optional parameters: `mapfn` and `thisArg`.
 
-`mapfn` is a mapping callback, which is called on each value yielded from the
-input (and awaited if it came from a synchronous input), along with its index
-integer (starting from 0). Each result of the mapping callback is, in turn,
-awaited then added to the array. By default, the callback is essentially an
-identity function.
+`mapfn` is an optional mapping callback, which is called on each value yielded
+from the input (and awaited if it came from a synchronous input), along with
+its index integer (starting from 0). Each result of the mapping callback is, in
+turn, awaited then added to the array.
+
+(Without the optional mapping callback, each value yielded from asynchronous
+inputs is not awaited, and each value yielded from synchronous inputs is
+awaited only once, before the value is added to the result array. This matches
+the behavior of `for await`.)
 
 `thisArg` is a `this`-binding receiver value for the mapping callback. By
 default, this is undefined. These optional parameters match the behavior of

--- a/spec.html
+++ b/spec.html
@@ -73,9 +73,9 @@ contributors: J. S. Choi
               1. Let _nextValue_ be ? IteratorValue(_next_).
               1. If _mapping_ is *true*, then
                 1. Let _mappedValue_ be Call(_mapfn_, _thisArg_, &laquo; _nextValue_, 𝔽(_k_) &raquo;).
-                1. IfAbruptCloseAsyncIterator(_iteratorRecord_, _mappedValue_).
+                1. IfAbruptCloseAsyncIterator(_mappedValue_, _iteratorRecord_).
                 1. Set _mappedValue_ to Await(_mappedValue_).
-                1. IfAbruptCloseAsyncIterator(_iteratorRecord_, _mappedValue_).
+                1. IfAbruptCloseAsyncIterator(_mappedValue_, _iteratorRecord_).
                 1. Set _mappedValue_ to _mappedValue_.[[Value]].
               1. Else, let _mappedValue_ be _nextValue_.
               1. Let _defineStatus_ be CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).

--- a/spec.html
+++ b/spec.html
@@ -74,10 +74,10 @@ contributors: J. S. Choi
               1. If _mapping_ is *true*, then
                 1. Let _mappedValue_ be Call(_mapfn_, _thisArg_, &laquo; _nextValue_, 𝔽(_k_) &raquo;).
                 1. IfAbruptCloseAsyncIterator(_iteratorRecord_, _mappedValue_).
+                1. Set _mappedValue_ to Await(_mappedValue_).
+                1. IfAbruptCloseAsyncIterator(_iteratorRecord_, _mappedValue_).
+                1. Set _mappedValue_ to _mappedValue_.[[Value]].
               1. Else, let _mappedValue_ be _nextValue_.
-              1. Set _mappedValue_ to Await(_mappedValue_).
-              1. IfAbruptCloseAsyncIterator(_iteratorRecord_, _mappedValue_).
-              1. Set _mappedValue_ to _mappedValue_.[[Value]].
               1. Let _defineStatus_ be CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
               1. If _defineStatus_ is an abrupt completion, return ? AsyncIteratorClose(_iteratorRecord_, _defineStatus_).
               1. Set _k_ to _k_ + 1.

--- a/spec.html
+++ b/spec.html
@@ -76,7 +76,6 @@ contributors: J. S. Choi
                 1. IfAbruptCloseAsyncIterator(_mappedValue_, _iteratorRecord_).
                 1. Set _mappedValue_ to Await(_mappedValue_).
                 1. IfAbruptCloseAsyncIterator(_mappedValue_, _iteratorRecord_).
-                1. Set _mappedValue_ to _mappedValue_.[[Value]].
               1. Else, let _mappedValue_ be _nextValue_.
               1. Let _defineStatus_ be CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
               1. If _defineStatus_ is an abrupt completion, return ? AsyncIteratorClose(_iteratorRecord_, _defineStatus_).


### PR DESCRIPTION
Resolves #19.
See <https://github.com/tc39/proposal-array-from-async/issues/19#issuecomment-1179810964>.

The intent is to match the behavior of `for await` and iterator-helpers’ `AsyncIterator.prototype.toArray`.