### PR TITLE
refactor: Copy Array.from’s array-like loop

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -120,37 +120,59 @@ contributors: J. S. Choi
               1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
               1. Let _mapping_ be *true*.
             1. Let _usingAsyncIterator_ be ? GetMethod(_asyncItems_, @@asyncIterator).
-            1. If _usingAsyncIterator_ is *undefined*,
+            1. If _usingAsyncIterator_ is *undefined*, then
               1. Let _usingSyncIterator_ be ? GetMethod(_asyncItems_, @@iterator).
-              1. If _usingSyncIterator_ is *undefined*, set _usingSyncIterator_ to %Array.prototype.values%.
             1. If IsConstructor(_C_) is *true*, then
               1. Let _A_ be ? Construct(_C_).
             1. Else,
               1. Let _A_ be ! ArrayCreate(0).
+            1. Let _iteratorRecord_ be *undefined*.
             1. If _usingAsyncIterator_ is not *undefined*, then
-              1. Let _iteratorRecord_ be ? GetIterator(_asyncItems_, ~async~, _usingAsyncIterator_).
+              1. Set _iteratorRecord_ to ? GetIterator(_asyncItems_, ~async~, _usingAsyncIterator_).
+            1. Else if _usingSyncIterator_ is not *undefined*, then
+              1. Set _iteratorRecord_ to ? CreateAsyncFromSyncIterator(GetIterator(_asyncItems_, ~sync~, _usingSyncIterator_)).
+            1. If _iteratorRecord_ is not *undefined*, then
+              1. Let _k_ be 0.
+              1. Repeat,
+                1. If _k_ &ge; 2<sup>53</sup> - 1, then
+                  1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+                  1. Return ? AsyncIteratorClose(_iteratorRecord_, _error_).
+                1. Let _Pk_ be ! ToString(𝔽(_k_)).
+                1. Let _next_ be ? Await(IteratorStep(_iteratorRecord_)).
+                1. If _next_ is *false*, then
+                  1. Perform ? Set(_A_, *"length"*, 𝔽(_k_), *true*).
+                  1. Return _A_.
+                1. Let _nextValue_ be ? IteratorValue(_next_).
+                1. If _mapping_ is *true*, then
+                  1. Let _mappedValue_ be Call(_mapfn_, _thisArg_, &laquo; _nextValue_, 𝔽(_k_) &raquo;).
+                  1. IfAbruptCloseAsyncIterator(_mappedValue_, _iteratorRecord_).
+                  1. Set _mappedValue_ to Await(_mappedValue_).
+                  1. IfAbruptCloseAsyncIterator(_mappedValue_, _iteratorRecord_).
+                1. Else, let _mappedValue_ be _nextValue_.
+                1. Let _defineStatus_ be CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
+                1. If _defineStatus_ is an abrupt completion, return ? AsyncIteratorClose(_iteratorRecord_, _defineStatus_).
+                1. Set _k_ to _k_ + 1.
             1. Else,
-              1. Let _iteratorRecord_ be ? CreateAsyncFromSyncIterator(GetIterator(_asyncItems_, ~sync~, _usingSyncIterator_)).
-            1. Let _k_ be 0.
-            1. Repeat,
-              1. If _k_ &ge; 2<sup>53</sup> - 1, then
-                1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
-                1. Return ? AsyncIteratorClose(_iteratorRecord_, _error_).
-              1. Let _Pk_ be ! ToString(𝔽(_k_)).
-              1. Let _next_ be ? Await(IteratorStep(_iteratorRecord_)).
-              1. If _next_ is *false*, then
-                1. Perform ? Set(_A_, *"length"*, 𝔽(_k_), *true*).
-                1. Return _A_.
-              1. Let _nextValue_ be ? IteratorValue(_next_).
-              1. If _mapping_ is *true*, then
-                1. Let _mappedValue_ be Call(_mapfn_, _thisArg_, &laquo; _nextValue_, 𝔽(_k_) &raquo;).
-                1. IfAbruptCloseAsyncIterator(_mappedValue_, _iteratorRecord_).
-                1. Set _mappedValue_ to Await(_mappedValue_).
-                1. IfAbruptCloseAsyncIterator(_mappedValue_, _iteratorRecord_).
-              1. Else, let _mappedValue_ be _nextValue_.
-              1. Let _defineStatus_ be CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
-              1. If _defineStatus_ is an abrupt completion, return ? AsyncIteratorClose(_iteratorRecord_, _defineStatus_).
-              1. Set _k_ to _k_ + 1.
+              1. NOTE: _asyncItems_ is neither an AsyncIterable nor an Iterable so assume it is an array-like object.
+              1. Let _arrayLike_ be ! ToObject(_asyncItems_).
+              1. Let _len_ be ? LengthOfArrayLike(_arrayLike_).
+              1. If IsConstructor(_C_) is *true*, then
+                1. Let _A_ be ? Construct(_C_, &laquo; 𝔽(_len_) &raquo;).
+              1. Else,
+                1. Let _A_ be ? ArrayCreate(_len_).
+              1. Let _k_ be 0.
+              1. Repeat, while _k_ &lt; _len_,
+                1. Let _Pk_ be ! ToString(𝔽(_k_)).
+                1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
+                1. Let _kValue_ be ? Await(_kValue_).
+                1. If _mapping_ is *true*, then
+                  1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_) &raquo;).
+                  1. Let _mappedValue_ be ? Await(_mappedValue_).
+                1. Else, let _mappedValue_ be _kValue_.
+                1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
+                1. Set _k_ to _k_ + 1.
+              1. Perform ? Set(_A_, *"length"*, 𝔽(_len_), *true*).
+              1. Return _A_.
           1. Perform AsyncFunctionStart(_promiseCapability_, _fromAsyncClosure_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>


### PR DESCRIPTION
Removes use of %Array.prototype.values%.
Closes #29.
Maybe in the future we can come back to this and simplify both Array.from and Array.fromAsync with %Array.prototype.values%. Because we haven’t confirmed that this is truly unobservable, today is not that day.