### PR TITLE
Normative: avoid double construction of `this` value

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -122,16 +122,16 @@ contributors: J. S. Choi
             1. Let _usingAsyncIterator_ be ? GetMethod(_asyncItems_, @@asyncIterator).
             1. If _usingAsyncIterator_ is *undefined*, then
               1. Let _usingSyncIterator_ be ? GetMethod(_asyncItems_, @@iterator).
-            1. If IsConstructor(_C_) is *true*, then
-              1. Let _A_ be ? Construct(_C_).
-            1. Else,
-              1. Let _A_ be ! ArrayCreate(0).
             1. Let _iteratorRecord_ be *undefined*.
             1. If _usingAsyncIterator_ is not *undefined*, then
               1. Set _iteratorRecord_ to ? GetIterator(_asyncItems_, ~async~, _usingAsyncIterator_).
             1. Else if _usingSyncIterator_ is not *undefined*, then
               1. Set _iteratorRecord_ to ? CreateAsyncFromSyncIterator(GetIterator(_asyncItems_, ~sync~, _usingSyncIterator_)).
             1. If _iteratorRecord_ is not *undefined*, then
+              1. If IsConstructor(_C_) is *true*, then
+                1. Let _A_ be ? Construct(_C_).
+              1. Else,
+                1. Let _A_ be ! ArrayCreate(0).
               1. Let _k_ be 0.
               1. Repeat,
                 1. If _k_ &ge; 2<sup>53</sup> - 1, then


### PR DESCRIPTION
Fixes #35. Requires consensus.