### PR TITLE
missing increment for i in for/await example

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Data.fromAsync = Array.fromAsync;
 // property assigned to `2`, etc.
 const d = new Data(0); let i = 0;
 for await (const v of asyncGen(4)) {
-  d[i] = v;
+  d[i++] = v;
 }
 
 // This is equivalent.


### PR DESCRIPTION
This fixes the for/await version of the `Data.fromAsync` example. 